### PR TITLE
Fix SocketTimeout errors

### DIFF
--- a/SignalA.LongPolling/src/main/java/com/zsoft/SignalA/transport/longpolling/ReconnectingState.java
+++ b/SignalA.LongPolling/src/main/java/com/zsoft/SignalA/transport/longpolling/ReconnectingState.java
@@ -123,6 +123,8 @@ public class ReconnectingState extends StopableStateWithCallback {
 
 		ParallelHttpClient httpClient = new ParallelHttpClient();
         httpClient.setMaxRetries(1);
+        httpClient.setConnectionTimeout(5000);
+	httpClient.setReadTimeout(115000);
         for (Map.Entry<String, String> entry : mConnection.getHeaders().entrySet())
         {
             httpClient.addHeader(entry.getKey(), entry.getValue());


### PR DESCRIPTION
I believe this will fix https://github.com/erizet/SignalA/issues/37

i had an event that signalR server was sending to the client that would break the connection. this prevents that breakage. 

It looks like setting the timeouts should have been here in the first place, but were forgotten.
either way, this shouldn't break anything.
