### PR TITLE
JSONHelper NullPointer  bug

### DIFF
--- a/SignalA.LongPolling/src/main/java/com/zsoft/SignalA/transport/longpolling/JSONHelper.java
+++ b/SignalA.LongPolling/src/main/java/com/zsoft/SignalA/transport/longpolling/JSONHelper.java
@@ -12,6 +12,8 @@ public class JSONHelper {
 			json = new JSONObject(text);
 		} catch (JSONException e) {
 			json = null;
+		} catch (NullPointerException e){
+			json = null;
 		}
 		return json;
 	}


### PR DESCRIPTION
When the network state is change ,it will be killed for nullpointer. So i just  use "catch (NullPointerException e)" to fix it.   If your network state changed  you maybe need reconnection。
